### PR TITLE
FEAT: Recipe model, controller and routes implementation

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -65,14 +65,101 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "22.5.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
       "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.16",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
+      "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/strip-bom": {
@@ -1333,8 +1420,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/node_modules/@types/body-parser/LICENSE
+++ b/node_modules/@types/body-parser/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/body-parser/README.md
+++ b/node_modules/@types/body-parser/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/body-parser`
+
+# Summary
+This package contains type definitions for body-parser (https://github.com/expressjs/body-parser).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/body-parser.
+
+### Additional Details
+ * Last updated: Mon, 06 Nov 2023 22:41:05 GMT
+ * Dependencies: [@types/connect](https://npmjs.com/package/@types/connect), [@types/node](https://npmjs.com/package/@types/node)
+
+# Credits
+These definitions were written by [Santi Albo](https://github.com/santialbo), [Vilic Vane](https://github.com/vilic), [Jonathan Häberle](https://github.com/dreampulse), [Gevik Babakhani](https://github.com/blendsdk), [Tomasz Łaziuk](https://github.com/tlaziuk), [Jason Walton](https://github.com/jwalton), and [Piotr Błażejewicz](https://github.com/peterblazejewicz).

--- a/node_modules/@types/body-parser/index.d.ts
+++ b/node_modules/@types/body-parser/index.d.ts
@@ -1,0 +1,95 @@
+/// <reference types="node" />
+
+import { NextHandleFunction } from "connect";
+import * as http from "http";
+
+// for docs go to https://github.com/expressjs/body-parser/tree/1.19.0#body-parser
+
+declare namespace bodyParser {
+    interface BodyParser {
+        /**
+         * @deprecated  use individual json/urlencoded middlewares
+         */
+        (options?: OptionsJson & OptionsText & OptionsUrlencoded): NextHandleFunction;
+        /**
+         * Returns middleware that only parses json and only looks at requests
+         * where the Content-Type header matches the type option.
+         */
+        json(options?: OptionsJson): NextHandleFunction;
+        /**
+         * Returns middleware that parses all bodies as a Buffer and only looks at requests
+         * where the Content-Type header matches the type option.
+         */
+        raw(options?: Options): NextHandleFunction;
+
+        /**
+         * Returns middleware that parses all bodies as a string and only looks at requests
+         * where the Content-Type header matches the type option.
+         */
+        text(options?: OptionsText): NextHandleFunction;
+        /**
+         * Returns middleware that only parses urlencoded bodies and only looks at requests
+         * where the Content-Type header matches the type option
+         */
+        urlencoded(options?: OptionsUrlencoded): NextHandleFunction;
+    }
+
+    interface Options {
+        /** When set to true, then deflated (compressed) bodies will be inflated; when false, deflated bodies are rejected. Defaults to true. */
+        inflate?: boolean | undefined;
+        /**
+         * Controls the maximum request body size. If this is a number,
+         * then the value specifies the number of bytes; if it is a string,
+         * the value is passed to the bytes library for parsing. Defaults to '100kb'.
+         */
+        limit?: number | string | undefined;
+        /**
+         * The type option is used to determine what media type the middleware will parse
+         */
+        type?: string | string[] | ((req: http.IncomingMessage) => any) | undefined;
+        /**
+         * The verify option, if supplied, is called as verify(req, res, buf, encoding),
+         * where buf is a Buffer of the raw request body and encoding is the encoding of the request.
+         */
+        verify?(req: http.IncomingMessage, res: http.ServerResponse, buf: Buffer, encoding: string): void;
+    }
+
+    interface OptionsJson extends Options {
+        /**
+         * The reviver option is passed directly to JSON.parse as the second argument.
+         */
+        reviver?(key: string, value: any): any;
+        /**
+         * When set to `true`, will only accept arrays and objects;
+         * when `false` will accept anything JSON.parse accepts. Defaults to `true`.
+         */
+        strict?: boolean | undefined;
+    }
+
+    interface OptionsText extends Options {
+        /**
+         * Specify the default character set for the text content if the charset
+         * is not specified in the Content-Type header of the request.
+         * Defaults to `utf-8`.
+         */
+        defaultCharset?: string | undefined;
+    }
+
+    interface OptionsUrlencoded extends Options {
+        /**
+         * The extended option allows to choose between parsing the URL-encoded data
+         * with the querystring library (when `false`) or the qs library (when `true`).
+         */
+        extended?: boolean | undefined;
+        /**
+         * The parameterLimit option controls the maximum number of parameters
+         * that are allowed in the URL-encoded data. If a request contains more parameters than this value,
+         * a 413 will be returned to the client. Defaults to 1000.
+         */
+        parameterLimit?: number | undefined;
+    }
+}
+
+declare const bodyParser: bodyParser.BodyParser;
+
+export = bodyParser;

--- a/node_modules/@types/body-parser/package.json
+++ b/node_modules/@types/body-parser/package.json
@@ -1,0 +1,58 @@
+{
+    "name": "@types/body-parser",
+    "version": "1.19.5",
+    "description": "TypeScript definitions for body-parser",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/body-parser",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Santi Albo",
+            "githubUsername": "santialbo",
+            "url": "https://github.com/santialbo"
+        },
+        {
+            "name": "Vilic Vane",
+            "githubUsername": "vilic",
+            "url": "https://github.com/vilic"
+        },
+        {
+            "name": "Jonathan Häberle",
+            "githubUsername": "dreampulse",
+            "url": "https://github.com/dreampulse"
+        },
+        {
+            "name": "Gevik Babakhani",
+            "githubUsername": "blendsdk",
+            "url": "https://github.com/blendsdk"
+        },
+        {
+            "name": "Tomasz Łaziuk",
+            "githubUsername": "tlaziuk",
+            "url": "https://github.com/tlaziuk"
+        },
+        {
+            "name": "Jason Walton",
+            "githubUsername": "jwalton",
+            "url": "https://github.com/jwalton"
+        },
+        {
+            "name": "Piotr Błażejewicz",
+            "githubUsername": "peterblazejewicz",
+            "url": "https://github.com/peterblazejewicz"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/body-parser"
+    },
+    "scripts": {},
+    "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+    },
+    "typesPublisherContentHash": "7be737b78c8aabd5436be840558b283182b44c3cf9da24fb1f2ff8f414db5802",
+    "typeScriptVersion": "4.5"
+}

--- a/node_modules/@types/connect/LICENSE
+++ b/node_modules/@types/connect/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/connect/README.md
+++ b/node_modules/@types/connect/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/connect`
+
+# Summary
+This package contains type definitions for connect (https://github.com/senchalabs/connect).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/connect.
+
+### Additional Details
+ * Last updated: Mon, 06 Nov 2023 22:41:05 GMT
+ * Dependencies: [@types/node](https://npmjs.com/package/@types/node)
+
+# Credits
+These definitions were written by [Maxime LUCE](https://github.com/SomaticIT), and [Evan Hahn](https://github.com/EvanHahn).

--- a/node_modules/@types/connect/index.d.ts
+++ b/node_modules/@types/connect/index.d.ts
@@ -1,0 +1,91 @@
+/// <reference types="node" />
+
+import * as http from "http";
+
+/**
+ * Create a new connect server.
+ */
+declare function createServer(): createServer.Server;
+
+declare namespace createServer {
+    export type ServerHandle = HandleFunction | http.Server;
+
+    export class IncomingMessage extends http.IncomingMessage {
+        originalUrl?: http.IncomingMessage["url"] | undefined;
+    }
+
+    type NextFunction = (err?: any) => void;
+
+    export type SimpleHandleFunction = (req: IncomingMessage, res: http.ServerResponse) => void;
+    export type NextHandleFunction = (req: IncomingMessage, res: http.ServerResponse, next: NextFunction) => void;
+    export type ErrorHandleFunction = (
+        err: any,
+        req: IncomingMessage,
+        res: http.ServerResponse,
+        next: NextFunction,
+    ) => void;
+    export type HandleFunction = SimpleHandleFunction | NextHandleFunction | ErrorHandleFunction;
+
+    export interface ServerStackItem {
+        route: string;
+        handle: ServerHandle;
+    }
+
+    export interface Server extends NodeJS.EventEmitter {
+        (req: http.IncomingMessage, res: http.ServerResponse, next?: Function): void;
+
+        route: string;
+        stack: ServerStackItem[];
+
+        /**
+         * Utilize the given middleware `handle` to the given `route`,
+         * defaulting to _/_. This "route" is the mount-point for the
+         * middleware, when given a value other than _/_ the middleware
+         * is only effective when that segment is present in the request's
+         * pathname.
+         *
+         * For example if we were to mount a function at _/admin_, it would
+         * be invoked on _/admin_, and _/admin/settings_, however it would
+         * not be invoked for _/_, or _/posts_.
+         */
+        use(fn: NextHandleFunction): Server;
+        use(fn: HandleFunction): Server;
+        use(route: string, fn: NextHandleFunction): Server;
+        use(route: string, fn: HandleFunction): Server;
+
+        /**
+         * Handle server requests, punting them down
+         * the middleware stack.
+         */
+        handle(req: http.IncomingMessage, res: http.ServerResponse, next: Function): void;
+
+        /**
+         * Listen for connections.
+         *
+         * This method takes the same arguments
+         * as node's `http.Server#listen()`.
+         *
+         * HTTP and HTTPS:
+         *
+         * If you run your application both as HTTP
+         * and HTTPS you may wrap them individually,
+         * since your Connect "server" is really just
+         * a JavaScript `Function`.
+         *
+         *      var connect = require('connect')
+         *        , http = require('http')
+         *        , https = require('https');
+         *
+         *      var app = connect();
+         *
+         *      http.createServer(app).listen(80);
+         *      https.createServer(options, app).listen(443);
+         */
+        listen(port: number, hostname?: string, backlog?: number, callback?: Function): http.Server;
+        listen(port: number, hostname?: string, callback?: Function): http.Server;
+        listen(path: string, callback?: Function): http.Server;
+        listen(handle: any, listeningListener?: Function): http.Server;
+    }
+}
+
+export = createServer;

--- a/node_modules/@types/connect/package.json
+++ b/node_modules/@types/connect/package.json
@@ -1,0 +1,32 @@
+{
+    "name": "@types/connect",
+    "version": "3.4.38",
+    "description": "TypeScript definitions for connect",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/connect",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Maxime LUCE",
+            "githubUsername": "SomaticIT",
+            "url": "https://github.com/SomaticIT"
+        },
+        {
+            "name": "Evan Hahn",
+            "githubUsername": "EvanHahn",
+            "url": "https://github.com/EvanHahn"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/connect"
+    },
+    "scripts": {},
+    "dependencies": {
+        "@types/node": "*"
+    },
+    "typesPublisherContentHash": "8990242237504bdec53088b79e314b94bec69286df9de56db31f22de403b4092",
+    "typeScriptVersion": "4.5"
+}

--- a/node_modules/@types/express-serve-static-core/LICENSE
+++ b/node_modules/@types/express-serve-static-core/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/express-serve-static-core/README.md
+++ b/node_modules/@types/express-serve-static-core/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/express-serve-static-core`
+
+# Summary
+This package contains type definitions for express-serve-static-core (http://expressjs.com).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/express-serve-static-core.
+
+### Additional Details
+ * Last updated: Wed, 19 Jun 2024 19:07:05 GMT
+ * Dependencies: [@types/node](https://npmjs.com/package/@types/node), [@types/qs](https://npmjs.com/package/@types/qs), [@types/range-parser](https://npmjs.com/package/@types/range-parser), [@types/send](https://npmjs.com/package/@types/send)
+
+# Credits
+These definitions were written by [Boris Yankov](https://github.com/borisyankov), [Satana Charuwichitratana](https://github.com/micksatana), [Jose Luis Leon](https://github.com/JoseLion), [David Stephens](https://github.com/dwrss), and [Shin Ando](https://github.com/andoshin11).

--- a/node_modules/@types/express-serve-static-core/index.d.ts
+++ b/node_modules/@types/express-serve-static-core/index.d.ts
@@ -1,0 +1,1295 @@
+// This extracts the core definitions from express to prevent a circular dependency between express and serve-static
+/// <reference types="node" />
+
+import { SendOptions } from "send";
+
+declare global {
+    namespace Express {
+        // These open interfaces may be extended in an application-specific manner via declaration merging.
+        // See for example method-override.d.ts (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/method-override/index.d.ts)
+        interface Request {}
+        interface Response {}
+        interface Locals {}
+        interface Application {}
+    }
+}
+
+import { EventEmitter } from "events";
+import * as http from "http";
+import { ParsedQs } from "qs";
+import { Options as RangeParserOptions, Ranges as RangeParserRanges, Result as RangeParserResult } from "range-parser";
+
+export {};
+
+export type Query = ParsedQs;
+
+export interface NextFunction {
+    (err?: any): void;
+    /**
+     * "Break-out" of a router by calling {next('router')};
+     * @see {https://expressjs.com/en/guide/using-middleware.html#middleware.router}
+     */
+    (deferToNext: "router"): void;
+    /**
+     * "Break-out" of a route by calling {next('route')};
+     * @see {https://expressjs.com/en/guide/using-middleware.html#middleware.application}
+     */
+    (deferToNext: "route"): void;
+}
+
+export interface Dictionary<T> {
+    [key: string]: T;
+}
+
+export interface ParamsDictionary {
+    [key: string]: string;
+}
+export type ParamsArray = string[];
+export type Params = ParamsDictionary | ParamsArray;
+
+export interface Locals extends Express.Locals {}
+
+export interface RequestHandler<
+    P = ParamsDictionary,
+    ResBody = any,
+    ReqBody = any,
+    ReqQuery = ParsedQs,
+    LocalsObj extends Record<string, any> = Record<string, any>,
+> {
+    // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2)
+    (
+        req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
+        res: Response<ResBody, LocalsObj>,
+        next: NextFunction,
+    ): void;
+}
+
+export type ErrorRequestHandler<
+    P = ParamsDictionary,
+    ResBody = any,
+    ReqBody = any,
+    ReqQuery = ParsedQs,
+    LocalsObj extends Record<string, any> = Record<string, any>,
+> = (
+    err: any,
+    req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
+    res: Response<ResBody, LocalsObj>,
+    next: NextFunction,
+) => void;
+
+export type PathParams = string | RegExp | Array<string | RegExp>;
+
+export type RequestHandlerParams<
+    P = ParamsDictionary,
+    ResBody = any,
+    ReqBody = any,
+    ReqQuery = ParsedQs,
+    LocalsObj extends Record<string, any> = Record<string, any>,
+> =
+    | RequestHandler<P, ResBody, ReqBody, ReqQuery, LocalsObj>
+    | ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery, LocalsObj>
+    | Array<RequestHandler<P> | ErrorRequestHandler<P>>;
+
+type RemoveTail<S extends string, Tail extends string> = S extends `${infer P}${Tail}` ? P : S;
+type GetRouteParameter<S extends string> = RemoveTail<
+    RemoveTail<RemoveTail<S, `/${string}`>, `-${string}`>,
+    `.${string}`
+>;
+
+// prettier-ignore
+export type RouteParameters<Route extends string> = string extends Route ? ParamsDictionary
+    : Route extends `${string}(${string}` ? ParamsDictionary // TODO: handling for regex parameters
+    : Route extends `${string}:${infer Rest}` ?
+            & (
+                GetRouteParameter<Rest> extends never ? ParamsDictionary
+                    : GetRouteParameter<Rest> extends `${infer ParamName}?` ? { [P in ParamName]?: string }
+                    : { [P in GetRouteParameter<Rest>]: string }
+            )
+            & (Rest extends `${GetRouteParameter<Rest>}${infer Next}` ? RouteParameters<Next> : unknown)
+    : {};
+
+/* eslint-disable @definitelytyped/no-unnecessary-generics */
+export interface IRouterMatcher<
+    T,
+    Method extends "all" | "get" | "post" | "put" | "delete" | "patch" | "options" | "head" = any,
+> {
+    <
+        Route extends string,
+        P = RouteParameters<Route>,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        LocalsObj extends Record<string, any> = Record<string, any>,
+    >(
+        // (it's used as the default type parameter for P)
+        path: Route,
+        // (This generic is meant to be passed explicitly.)
+        ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, LocalsObj>>
+    ): T;
+    <
+        Path extends string,
+        P = RouteParameters<Path>,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        LocalsObj extends Record<string, any> = Record<string, any>,
+    >(
+        // (it's used as the default type parameter for P)
+        path: Path,
+        // (This generic is meant to be passed explicitly.)
+        ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery, LocalsObj>>
+    ): T;
+    <
+        P = ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        LocalsObj extends Record<string, any> = Record<string, any>,
+    >(
+        path: PathParams,
+        // (This generic is meant to be passed explicitly.)
+        ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, LocalsObj>>
+    ): T;
+    <
+        P = ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        LocalsObj extends Record<string, any> = Record<string, any>,
+    >(
+        path: PathParams,
+        // (This generic is meant to be passed explicitly.)
+        ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery, LocalsObj>>
+    ): T;
+    (path: PathParams, subApplication: Application): T;
+}
+
+export interface IRouterHandler<T, Route extends string = string> {
+    (...handlers: Array<RequestHandler<RouteParameters<Route>>>): T;
+    (...handlers: Array<RequestHandlerParams<RouteParameters<Route>>>): T;
+    <
+        P = RouteParameters<Route>,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        LocalsObj extends Record<string, any> = Record<string, any>,
+    >(
+        // (This generic is meant to be passed explicitly.)
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, LocalsObj>>
+    ): T;
+    <
+        P = RouteParameters<Route>,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        LocalsObj extends Record<string, any> = Record<string, any>,
+    >(
+        // (This generic is meant to be passed explicitly.)
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery, LocalsObj>>
+    ): T;
+    <
+        P = ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        LocalsObj extends Record<string, any> = Record<string, any>,
+    >(
+        // (This generic is meant to be passed explicitly.)
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, LocalsObj>>
+    ): T;
+    <
+        P = ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        LocalsObj extends Record<string, any> = Record<string, any>,
+    >(
+        // (This generic is meant to be passed explicitly.)
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery, LocalsObj>>
+    ): T;
+}
+/* eslint-enable @definitelytyped/no-unnecessary-generics */
+
+export interface IRouter extends RequestHandler {
+    /**
+     * Map the given param placeholder `name`(s) to the given callback(s).
+     *
+     * Parameter mapping is used to provide pre-conditions to routes
+     * which use normalized placeholders. For example a _:user_id_ parameter
+     * could automatically load a user's information from the database without
+     * any additional code,
+     *
+     * The callback uses the samesignature as middleware, the only differencing
+     * being that the value of the placeholder is passed, in this case the _id_
+     * of the user. Once the `next()` function is invoked, just like middleware
+     * it will continue on to execute the route, or subsequent parameter functions.
+     *
+     *      app.param('user_id', function(req, res, next, id){
+     *        User.find(id, function(err, user){
+     *          if (err) {
+     *            next(err);
+     *          } else if (user) {
+     *            req.user = user;
+     *            next();
+     *          } else {
+     *            next(new Error('failed to load user'));
+     *          }
+     *        });
+     *      });
+     */
+    param(name: string, handler: RequestParamHandler): this;
+
+    /**
+     * Alternatively, you can pass only a callback, in which case you have the opportunity to alter the app.param()
+     *
+     * @deprecated since version 4.11
+     */
+    param(callback: (name: string, matcher: RegExp) => RequestParamHandler): this;
+
+    /**
+     * Special-cased "all" method, applying the given route `path`,
+     * middleware, and callback to _every_ HTTP method.
+     */
+    all: IRouterMatcher<this, "all">;
+    get: IRouterMatcher<this, "get">;
+    post: IRouterMatcher<this, "post">;
+    put: IRouterMatcher<this, "put">;
+    delete: IRouterMatcher<this, "delete">;
+    patch: IRouterMatcher<this, "patch">;
+    options: IRouterMatcher<this, "options">;
+    head: IRouterMatcher<this, "head">;
+
+    checkout: IRouterMatcher<this>;
+    connect: IRouterMatcher<this>;
+    copy: IRouterMatcher<this>;
+    lock: IRouterMatcher<this>;
+    merge: IRouterMatcher<this>;
+    mkactivity: IRouterMatcher<this>;
+    mkcol: IRouterMatcher<this>;
+    move: IRouterMatcher<this>;
+    "m-search": IRouterMatcher<this>;
+    notify: IRouterMatcher<this>;
+    propfind: IRouterMatcher<this>;
+    proppatch: IRouterMatcher<this>;
+    purge: IRouterMatcher<this>;
+    report: IRouterMatcher<this>;
+    search: IRouterMatcher<this>;
+    subscribe: IRouterMatcher<this>;
+    trace: IRouterMatcher<this>;
+    unlock: IRouterMatcher<this>;
+    unsubscribe: IRouterMatcher<this>;
+    link: IRouterMatcher<this>;
+    unlink: IRouterMatcher<this>;
+
+    use: IRouterHandler<this> & IRouterMatcher<this>;
+
+    route<T extends string>(prefix: T): IRoute<T>;
+    route(prefix: PathParams): IRoute;
+    /**
+     * Stack of configured routes
+     */
+    stack: ILayer[];
+}
+
+export interface ILayer {
+    route?: IRoute;
+    name: string | "<anonymous>";
+    params?: Record<string, any>;
+    keys: string[];
+    path?: string;
+    method: string;
+    regexp: RegExp;
+    handle: (req: Request, res: Response, next: NextFunction) => any;
+}
+
+export interface IRoute<Route extends string = string> {
+    path: string;
+    stack: ILayer[];
+    all: IRouterHandler<this, Route>;
+    get: IRouterHandler<this, Route>;
+    post: IRouterHandler<this, Route>;
+    put: IRouterHandler<this, Route>;
+    delete: IRouterHandler<this, Route>;
+    patch: IRouterHandler<this, Route>;
+    options: IRouterHandler<this, Route>;
+    head: IRouterHandler<this, Route>;
+
+    checkout: IRouterHandler<this, Route>;
+    copy: IRouterHandler<this, Route>;
+    lock: IRouterHandler<this, Route>;
+    merge: IRouterHandler<this, Route>;
+    mkactivity: IRouterHandler<this, Route>;
+    mkcol: IRouterHandler<this, Route>;
+    move: IRouterHandler<this, Route>;
+    "m-search": IRouterHandler<this, Route>;
+    notify: IRouterHandler<this, Route>;
+    purge: IRouterHandler<this, Route>;
+    report: IRouterHandler<this, Route>;
+    search: IRouterHandler<this, Route>;
+    subscribe: IRouterHandler<this, Route>;
+    trace: IRouterHandler<this, Route>;
+    unlock: IRouterHandler<this, Route>;
+    unsubscribe: IRouterHandler<this, Route>;
+}
+
+export interface Router extends IRouter {}
+
+/**
+ * Options passed down into `res.cookie`
+ * @link https://expressjs.com/en/api.html#res.cookie
+ */
+export interface CookieOptions {
+    /** Convenient option for setting the expiry time relative to the current time in **milliseconds**. */
+    maxAge?: number | undefined;
+    /** Indicates if the cookie should be signed. */
+    signed?: boolean | undefined;
+    /** Expiry date of the cookie in GMT. If not specified or set to 0, creates a session cookie. */
+    expires?: Date | undefined;
+    /** Flags the cookie to be accessible only by the web server. */
+    httpOnly?: boolean | undefined;
+    /** Path for the cookie. Defaults to “/”. */
+    path?: string | undefined;
+    /** Domain name for the cookie. Defaults to the domain name of the app. */
+    domain?: string | undefined;
+    /** Marks the cookie to be used with HTTPS only. */
+    secure?: boolean | undefined;
+    /** A synchronous function used for cookie value encoding. Defaults to encodeURIComponent. */
+    encode?: ((val: string) => string) | undefined;
+    /**
+     * Value of the “SameSite” Set-Cookie attribute.
+     * @link https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1.
+     */
+    sameSite?: boolean | "lax" | "strict" | "none" | undefined;
+    /**
+     * Value of the “Priority” Set-Cookie attribute.
+     * @link https://datatracker.ietf.org/doc/html/draft-west-cookie-priority-00#section-4.3
+     */
+    priority?: "low" | "medium" | "high";
+    /** Marks the cookie to use partioned storage. */
+    partitioned?: boolean | undefined;
+}
+
+export interface ByteRange {
+    start: number;
+    end: number;
+}
+
+export interface RequestRanges extends RangeParserRanges {}
+
+export type Errback = (err: Error) => void;
+
+/**
+ * @param P  For most requests, this should be `ParamsDictionary`, but if you're
+ * using this in a route handler for a route that uses a `RegExp` or a wildcard
+ * `string` path (e.g. `'/user/*'`), then `req.params` will be an array, in
+ * which case you should use `ParamsArray` instead.
+ *
+ * @see https://expressjs.com/en/api.html#req.params
+ *
+ * @example
+ *     app.get('/user/:id', (req, res) => res.send(req.params.id)); // implicitly `ParamsDictionary`
+ *     app.get<ParamsArray>(/user\/(.*)/, (req, res) => res.send(req.params[0]));
+ *     app.get<ParamsArray>('/user/*', (req, res) => res.send(req.params[0]));
+ */
+export interface Request<
+    P = ParamsDictionary,
+    ResBody = any,
+    ReqBody = any,
+    ReqQuery = ParsedQs,
+    LocalsObj extends Record<string, any> = Record<string, any>,
+> extends http.IncomingMessage, Express.Request {
+    /**
+     * Return request header.
+     *
+     * The `Referrer` header field is special-cased,
+     * both `Referrer` and `Referer` are interchangeable.
+     *
+     * Examples:
+     *
+     *     req.get('Content-Type');
+     *     // => "text/plain"
+     *
+     *     req.get('content-type');
+     *     // => "text/plain"
+     *
+     *     req.get('Something');
+     *     // => undefined
+     *
+     * Aliased as `req.header()`.
+     */
+    get(name: "set-cookie"): string[] | undefined;
+    get(name: string): string | undefined;
+
+    header(name: "set-cookie"): string[] | undefined;
+    header(name: string): string | undefined;
+
+    /**
+     * Check if the given `type(s)` is acceptable, returning
+     * the best match when true, otherwise `undefined`, in which
+     * case you should respond with 406 "Not Acceptable".
+     *
+     * The `type` value may be a single mime type string
+     * such as "application/json", the extension name
+     * such as "json", a comma-delimted list such as "json, html, text/plain",
+     * or an array `["json", "html", "text/plain"]`. When a list
+     * or array is given the _best_ match, if any is returned.
+     *
+     * Examples:
+     *
+     *     // Accept: text/html
+     *     req.accepts('html');
+     *     // => "html"
+     *
+     *     // Accept: text/*, application/json
+     *     req.accepts('html');
+     *     // => "html"
+     *     req.accepts('text/html');
+     *     // => "text/html"
+     *     req.accepts('json, text');
+     *     // => "json"
+     *     req.accepts('application/json');
+     *     // => "application/json"
+     *
+     *     // Accept: text/*, application/json
+     *     req.accepts('image/png');
+     *     req.accepts('png');
+     *     // => false
+     *
+     *     // Accept: text/*;q=.5, application/json
+     *     req.accepts(['html', 'json']);
+     *     req.accepts('html, json');
+     *     // => "json"
+     */
+    accepts(): string[];
+    accepts(type: string): string | false;
+    accepts(type: string[]): string | false;
+    accepts(...type: string[]): string | false;
+
+    /**
+     * Returns the first accepted charset of the specified character sets,
+     * based on the request's Accept-Charset HTTP header field.
+     * If none of the specified charsets is accepted, returns false.
+     *
+     * For more information, or if you have issues or concerns, see accepts.
+     */
+    acceptsCharsets(): string[];
+    acceptsCharsets(charset: string): string | false;
+    acceptsCharsets(charset: string[]): string | false;
+    acceptsCharsets(...charset: string[]): string | false;
+
+    /**
+     * Returns the first accepted encoding of the specified encodings,
+     * based on the request's Accept-Encoding HTTP header field.
+     * If none of the specified encodings is accepted, returns false.
+     *
+     * For more information, or if you have issues or concerns, see accepts.
+     */
+    acceptsEncodings(): string[];
+    acceptsEncodings(encoding: string): string | false;
+    acceptsEncodings(encoding: string[]): string | false;
+    acceptsEncodings(...encoding: string[]): string | false;
+
+    /**
+     * Returns the first accepted language of the specified languages,
+     * based on the request's Accept-Language HTTP header field.
+     * If none of the specified languages is accepted, returns false.
+     *
+     * For more information, or if you have issues or concerns, see accepts.
+     */
+    acceptsLanguages(): string[];
+    acceptsLanguages(lang: string): string | false;
+    acceptsLanguages(lang: string[]): string | false;
+    acceptsLanguages(...lang: string[]): string | false;
+
+    /**
+     * Parse Range header field, capping to the given `size`.
+     *
+     * Unspecified ranges such as "0-" require knowledge of your resource length. In
+     * the case of a byte range this is of course the total number of bytes.
+     * If the Range header field is not given `undefined` is returned.
+     * If the Range header field is given, return value is a result of range-parser.
+     * See more ./types/range-parser/index.d.ts
+     *
+     * NOTE: remember that ranges are inclusive, so for example "Range: users=0-3"
+     * should respond with 4 users when available, not 3.
+     */
+    range(size: number, options?: RangeParserOptions): RangeParserRanges | RangeParserResult | undefined;
+
+    /**
+     * Return an array of Accepted media types
+     * ordered from highest quality to lowest.
+     */
+    accepted: MediaType[];
+
+    /**
+     * @deprecated since 4.11 Use either req.params, req.body or req.query, as applicable.
+     *
+     * Return the value of param `name` when present or `defaultValue`.
+     *
+     *  - Checks route placeholders, ex: _/user/:id_
+     *  - Checks body params, ex: id=12, {"id":12}
+     *  - Checks query string params, ex: ?id=12
+     *
+     * To utilize request bodies, `req.body`
+     * should be an object. This can be done by using
+     * the `connect.bodyParser()` middleware.
+     */
+    param(name: string, defaultValue?: any): string;
+
+    /**
+     * Check if the incoming request contains the "Content-Type"
+     * header field, and it contains the give mime `type`.
+     *
+     * Examples:
+     *
+     *      // With Content-Type: text/html; charset=utf-8
+     *      req.is('html');
+     *      req.is('text/html');
+     *      req.is('text/*');
+     *      // => true
+     *
+     *      // When Content-Type is application/json
+     *      req.is('json');
+     *      req.is('application/json');
+     *      req.is('application/*');
+     *      // => true
+     *
+     *      req.is('html');
+     *      // => false
+     */
+    is(type: string | string[]): string | false | null;
+
+    /**
+     * Return the protocol string "http" or "https"
+     * when requested with TLS. When the "trust proxy"
+     * setting is enabled the "X-Forwarded-Proto" header
+     * field will be trusted. If you're running behind
+     * a reverse proxy that supplies https for you this
+     * may be enabled.
+     */
+    readonly protocol: string;
+
+    /**
+     * Short-hand for:
+     *
+     *    req.protocol == 'https'
+     */
+    readonly secure: boolean;
+
+    /**
+     * Return the remote address, or when
+     * "trust proxy" is `true` return
+     * the upstream addr.
+     *
+     * Value may be undefined if the `req.socket` is destroyed
+     * (for example, if the client disconnected).
+     */
+    readonly ip: string | undefined;
+
+    /**
+     * When "trust proxy" is `true`, parse
+     * the "X-Forwarded-For" ip address list.
+     *
+     * For example if the value were "client, proxy1, proxy2"
+     * you would receive the array `["client", "proxy1", "proxy2"]`
+     * where "proxy2" is the furthest down-stream.
+     */
+    readonly ips: string[];
+
+    /**
+     * Return subdomains as an array.
+     *
+     * Subdomains are the dot-separated parts of the host before the main domain of
+     * the app. By default, the domain of the app is assumed to be the last two
+     * parts of the host. This can be changed by setting "subdomain offset".
+     *
+     * For example, if the domain is "tobi.ferrets.example.com":
+     * If "subdomain offset" is not set, req.subdomains is `["ferrets", "tobi"]`.
+     * If "subdomain offset" is 3, req.subdomains is `["tobi"]`.
+     */
+    readonly subdomains: string[];
+
+    /**
+     * Short-hand for `url.parse(req.url).pathname`.
+     */
+    readonly path: string;
+
+    /**
+     * Parse the "Host" header field hostname.
+     */
+    readonly hostname: string;
+
+    /**
+     * @deprecated Use hostname instead.
+     */
+    readonly host: string;
+
+    /**
+     * Check if the request is fresh, aka
+     * Last-Modified and/or the ETag
+     * still match.
+     */
+    readonly fresh: boolean;
+
+    /**
+     * Check if the request is stale, aka
+     * "Last-Modified" and / or the "ETag" for the
+     * resource has changed.
+     */
+    readonly stale: boolean;
+
+    /**
+     * Check if the request was an _XMLHttpRequest_.
+     */
+    readonly xhr: boolean;
+
+    // body: { username: string; password: string; remember: boolean; title: string; };
+    body: ReqBody;
+
+    // cookies: { string; remember: boolean; };
+    cookies: any;
+
+    method: string;
+
+    params: P;
+
+    query: ReqQuery;
+
+    route: any;
+
+    signedCookies: any;
+
+    originalUrl: string;
+
+    url: string;
+
+    baseUrl: string;
+
+    app: Application;
+
+    /**
+     * After middleware.init executed, Request will contain res and next properties
+     * See: express/lib/middleware/init.js
+     */
+    res?: Response<ResBody, LocalsObj> | undefined;
+    next?: NextFunction | undefined;
+}
+
+export interface MediaType {
+    value: string;
+    quality: number;
+    type: string;
+    subtype: string;
+}
+
+export type Send<ResBody = any, T = Response<ResBody>> = (body?: ResBody) => T;
+
+export interface SendFileOptions extends SendOptions {
+    /** Object containing HTTP headers to serve with the file. */
+    headers?: Record<string, unknown>;
+}
+
+export interface DownloadOptions extends SendOptions {
+    /** Object containing HTTP headers to serve with the file. The header `Content-Disposition` will be overridden by the filename argument. */
+    headers?: Record<string, unknown>;
+}
+
+export interface Response<
+    ResBody = any,
+    LocalsObj extends Record<string, any> = Record<string, any>,
+    StatusCode extends number = number,
+> extends http.ServerResponse, Express.Response {
+    /**
+     * Set status `code`.
+     */
+    status(code: StatusCode): this;
+
+    /**
+     * Set the response HTTP status code to `statusCode` and send its string representation as the response body.
+     * @link http://expressjs.com/4x/api.html#res.sendStatus
+     *
+     * Examples:
+     *
+     *    res.sendStatus(200); // equivalent to res.status(200).send('OK')
+     *    res.sendStatus(403); // equivalent to res.status(403).send('Forbidden')
+     *    res.sendStatus(404); // equivalent to res.status(404).send('Not Found')
+     *    res.sendStatus(500); // equivalent to res.status(500).send('Internal Server Error')
+     */
+    sendStatus(code: StatusCode): this;
+
+    /**
+     * Set Link header field with the given `links`.
+     *
+     * Examples:
+     *
+     *    res.links({
+     *      next: 'http://api.example.com/users?page=2',
+     *      last: 'http://api.example.com/users?page=5'
+     *    });
+     */
+    links(links: any): this;
+
+    /**
+     * Send a response.
+     *
+     * Examples:
+     *
+     *     res.send(new Buffer('wahoo'));
+     *     res.send({ some: 'json' });
+     *     res.send('<p>some html</p>');
+     *     res.status(404).send('Sorry, cant find that');
+     */
+    send: Send<ResBody, this>;
+
+    /**
+     * Send JSON response.
+     *
+     * Examples:
+     *
+     *     res.json(null);
+     *     res.json({ user: 'tj' });
+     *     res.status(500).json('oh noes!');
+     *     res.status(404).json('I dont have that');
+     */
+    json: Send<ResBody, this>;
+
+    /**
+     * Send JSON response with JSONP callback support.
+     *
+     * Examples:
+     *
+     *     res.jsonp(null);
+     *     res.jsonp({ user: 'tj' });
+     *     res.status(500).jsonp('oh noes!');
+     *     res.status(404).jsonp('I dont have that');
+     */
+    jsonp: Send<ResBody, this>;
+
+    /**
+     * Transfer the file at the given `path`.
+     *
+     * Automatically sets the _Content-Type_ response header field.
+     * The callback `fn(err)` is invoked when the transfer is complete
+     * or when an error occurs. Be sure to check `res.headersSent`
+     * if you wish to attempt responding, as the header and some data
+     * may have already been transferred.
+     *
+     * Options:
+     *
+     *   - `maxAge`   defaulting to 0 (can be string converted by `ms`)
+     *   - `root`     root directory for relative filenames
+     *   - `headers`  object of headers to serve with file
+     *   - `dotfiles` serve dotfiles, defaulting to false; can be `"allow"` to send them
+     *
+     * Other options are passed along to `send`.
+     *
+     * Examples:
+     *
+     *  The following example illustrates how `res.sendFile()` may
+     *  be used as an alternative for the `static()` middleware for
+     *  dynamic situations. The code backing `res.sendFile()` is actually
+     *  the same code, so HTTP cache support etc is identical.
+     *
+     *     app.get('/user/:uid/photos/:file', function(req, res){
+     *       var uid = req.params.uid
+     *         , file = req.params.file;
+     *
+     *       req.user.mayViewFilesFrom(uid, function(yes){
+     *         if (yes) {
+     *           res.sendFile('/uploads/' + uid + '/' + file);
+     *         } else {
+     *           res.send(403, 'Sorry! you cant see that.');
+     *         }
+     *       });
+     *     });
+     *
+     * @api public
+     */
+    sendFile(path: string, fn?: Errback): void;
+    sendFile(path: string, options: SendFileOptions, fn?: Errback): void;
+
+    /**
+     * @deprecated Use sendFile instead.
+     */
+    sendfile(path: string): void;
+    /**
+     * @deprecated Use sendFile instead.
+     */
+    sendfile(path: string, options: SendFileOptions): void;
+    /**
+     * @deprecated Use sendFile instead.
+     */
+    sendfile(path: string, fn: Errback): void;
+    /**
+     * @deprecated Use sendFile instead.
+     */
+    sendfile(path: string, options: SendFileOptions, fn: Errback): void;
+
+    /**
+     * Transfer the file at the given `path` as an attachment.
+     *
+     * Optionally providing an alternate attachment `filename`,
+     * and optional callback `fn(err)`. The callback is invoked
+     * when the data transfer is complete, or when an error has
+     * ocurred. Be sure to check `res.headersSent` if you plan to respond.
+     *
+     * The optional options argument passes through to the underlying
+     * res.sendFile() call, and takes the exact same parameters.
+     *
+     * This method uses `res.sendfile()`.
+     */
+    download(path: string, fn?: Errback): void;
+    download(path: string, filename: string, fn?: Errback): void;
+    download(path: string, filename: string, options: DownloadOptions, fn?: Errback): void;
+
+    /**
+     * Set _Content-Type_ response header with `type` through `mime.lookup()`
+     * when it does not contain "/", or set the Content-Type to `type` otherwise.
+     *
+     * Examples:
+     *
+     *     res.type('.html');
+     *     res.type('html');
+     *     res.type('json');
+     *     res.type('application/json');
+     *     res.type('png');
+     */
+    contentType(type: string): this;
+
+    /**
+     * Set _Content-Type_ response header with `type` through `mime.lookup()`
+     * when it does not contain "/", or set the Content-Type to `type` otherwise.
+     *
+     * Examples:
+     *
+     *     res.type('.html');
+     *     res.type('html');
+     *     res.type('json');
+     *     res.type('application/json');
+     *     res.type('png');
+     */
+    type(type: string): this;
+
+    /**
+     * Respond to the Acceptable formats using an `obj`
+     * of mime-type callbacks.
+     *
+     * This method uses `req.accepted`, an array of
+     * acceptable types ordered by their quality values.
+     * When "Accept" is not present the _first_ callback
+     * is invoked, otherwise the first match is used. When
+     * no match is performed the server responds with
+     * 406 "Not Acceptable".
+     *
+     * Content-Type is set for you, however if you choose
+     * you may alter this within the callback using `res.type()`
+     * or `res.set('Content-Type', ...)`.
+     *
+     *    res.format({
+     *      'text/plain': function(){
+     *        res.send('hey');
+     *      },
+     *
+     *      'text/html': function(){
+     *        res.send('<p>hey</p>');
+     *      },
+     *
+     *      'appliation/json': function(){
+     *        res.send({ message: 'hey' });
+     *      }
+     *    });
+     *
+     * In addition to canonicalized MIME types you may
+     * also use extnames mapped to these types:
+     *
+     *    res.format({
+     *      text: function(){
+     *        res.send('hey');
+     *      },
+     *
+     *      html: function(){
+     *        res.send('<p>hey</p>');
+     *      },
+     *
+     *      json: function(){
+     *        res.send({ message: 'hey' });
+     *      }
+     *    });
+     *
+     * By default Express passes an `Error`
+     * with a `.status` of 406 to `next(err)`
+     * if a match is not made. If you provide
+     * a `.default` callback it will be invoked
+     * instead.
+     */
+    format(obj: any): this;
+
+    /**
+     * Set _Content-Disposition_ header to _attachment_ with optional `filename`.
+     */
+    attachment(filename?: string): this;
+
+    /**
+     * Set header `field` to `val`, or pass
+     * an object of header fields.
+     *
+     * Examples:
+     *
+     *    res.set('Foo', ['bar', 'baz']);
+     *    res.set('Accept', 'application/json');
+     *    res.set({ Accept: 'text/plain', 'X-API-Key': 'tobi' });
+     *
+     * Aliased as `res.header()`.
+     */
+    set(field: any): this;
+    set(field: string, value?: string | string[]): this;
+
+    header(field: any): this;
+    header(field: string, value?: string | string[]): this;
+
+    // Property indicating if HTTP headers has been sent for the response.
+    headersSent: boolean;
+
+    /** Get value for header `field`. */
+    get(field: string): string | undefined;
+
+    /** Clear cookie `name`. */
+    clearCookie(name: string, options?: CookieOptions): this;
+
+    /**
+     * Set cookie `name` to `val`, with the given `options`.
+     *
+     * Options:
+     *
+     *    - `maxAge`   max-age in milliseconds, converted to `expires`
+     *    - `signed`   sign the cookie
+     *    - `path`     defaults to "/"
+     *
+     * Examples:
+     *
+     *    // "Remember Me" for 15 minutes
+     *    res.cookie('rememberme', '1', { expires: new Date(Date.now() + 900000), httpOnly: true });
+     *
+     *    // save as above
+     *    res.cookie('rememberme', '1', { maxAge: 900000, httpOnly: true })
+     */
+    cookie(name: string, val: string, options: CookieOptions): this;
+    cookie(name: string, val: any, options: CookieOptions): this;
+    cookie(name: string, val: any): this;
+
+    /**
+     * Set the location header to `url`.
+     *
+     * The given `url` can also be the name of a mapped url, for
+     * example by default express supports "back" which redirects
+     * to the _Referrer_ or _Referer_ headers or "/".
+     *
+     * Examples:
+     *
+     *    res.location('/foo/bar').;
+     *    res.location('http://example.com');
+     *    res.location('../login'); // /blog/post/1 -> /blog/login
+     *
+     * Mounting:
+     *
+     *   When an application is mounted and `res.location()`
+     *   is given a path that does _not_ lead with "/" it becomes
+     *   relative to the mount-point. For example if the application
+     *   is mounted at "/blog", the following would become "/blog/login".
+     *
+     *      res.location('login');
+     *
+     *   While the leading slash would result in a location of "/login":
+     *
+     *      res.location('/login');
+     */
+    location(url: string): this;
+
+    /**
+     * Redirect to the given `url` with optional response `status`
+     * defaulting to 302.
+     *
+     * The resulting `url` is determined by `res.location()`, so
+     * it will play nicely with mounted apps, relative paths,
+     * `"back"` etc.
+     *
+     * Examples:
+     *
+     *    res.redirect('back');
+     *    res.redirect('/foo/bar');
+     *    res.redirect('http://example.com');
+     *    res.redirect(301, 'http://example.com');
+     *    res.redirect('http://example.com', 301);
+     *    res.redirect('../login'); // /blog/post/1 -> /blog/login
+     */
+    redirect(url: string): void;
+    redirect(status: number, url: string): void;
+    /** @deprecated use res.redirect(status, url) instead */
+    redirect(url: string, status: number): void;
+
+    /**
+     * Render `view` with the given `options` and optional callback `fn`.
+     * When a callback function is given a response will _not_ be made
+     * automatically, otherwise a response of _200_ and _text/html_ is given.
+     *
+     * Options:
+     *
+     *  - `cache`     boolean hinting to the engine it should cache
+     *  - `filename`  filename of the view being rendered
+     */
+    render(view: string, options?: object, callback?: (err: Error, html: string) => void): void;
+    render(view: string, callback?: (err: Error, html: string) => void): void;
+
+    locals: LocalsObj & Locals;
+
+    charset: string;
+
+    /**
+     * Adds the field to the Vary response header, if it is not there already.
+     * Examples:
+     *
+     *     res.vary('User-Agent').render('docs');
+     */
+    vary(field: string): this;
+
+    app: Application;
+
+    /**
+     * Appends the specified value to the HTTP response header field.
+     * If the header is not already set, it creates the header with the specified value.
+     * The value parameter can be a string or an array.
+     *
+     * Note: calling res.set() after res.append() will reset the previously-set header value.
+     *
+     * @since 4.11.0
+     */
+    append(field: string, value?: string[] | string): this;
+
+    /**
+     * After middleware.init executed, Response will contain req property
+     * See: express/lib/middleware/init.js
+     */
+    req: Request;
+}
+
+export interface Handler extends RequestHandler {}
+
+export type RequestParamHandler = (req: Request, res: Response, next: NextFunction, value: any, name: string) => any;
+
+export type ApplicationRequestHandler<T> =
+    & IRouterHandler<T>
+    & IRouterMatcher<T>
+    & ((...handlers: RequestHandlerParams[]) => T);
+
+export interface Application<
+    LocalsObj extends Record<string, any> = Record<string, any>,
+> extends EventEmitter, IRouter, Express.Application {
+    /**
+     * Express instance itself is a request handler, which could be invoked without
+     * third argument.
+     */
+    (req: Request | http.IncomingMessage, res: Response | http.ServerResponse): any;
+
+    /**
+     * Initialize the server.
+     *
+     *   - setup default configuration
+     *   - setup default middleware
+     *   - setup route reflection methods
+     */
+    init(): void;
+
+    /**
+     * Initialize application configuration.
+     */
+    defaultConfiguration(): void;
+
+    /**
+     * Register the given template engine callback `fn`
+     * as `ext`.
+     *
+     * By default will `require()` the engine based on the
+     * file extension. For example if you try to render
+     * a "foo.jade" file Express will invoke the following internally:
+     *
+     *     app.engine('jade', require('jade').__express);
+     *
+     * For engines that do not provide `.__express` out of the box,
+     * or if you wish to "map" a different extension to the template engine
+     * you may use this method. For example mapping the EJS template engine to
+     * ".html" files:
+     *
+     *     app.engine('html', require('ejs').renderFile);
+     *
+     * In this case EJS provides a `.renderFile()` method with
+     * the same signature that Express expects: `(path, options, callback)`,
+     * though note that it aliases this method as `ejs.__express` internally
+     * so if you're using ".ejs" extensions you dont need to do anything.
+     *
+     * Some template engines do not follow this convention, the
+     * [Consolidate.js](https://github.com/visionmedia/consolidate.js)
+     * library was created to map all of node's popular template
+     * engines to follow this convention, thus allowing them to
+     * work seamlessly within Express.
+     */
+    engine(
+        ext: string,
+        fn: (path: string, options: object, callback: (e: any, rendered?: string) => void) => void,
+    ): this;
+
+    /**
+     * Assign `setting` to `val`, or return `setting`'s value.
+     *
+     *    app.set('foo', 'bar');
+     *    app.get('foo');
+     *    // => "bar"
+     *    app.set('foo', ['bar', 'baz']);
+     *    app.get('foo');
+     *    // => ["bar", "baz"]
+     *
+     * Mounted servers inherit their parent server's settings.
+     */
+    set(setting: string, val: any): this;
+    get: ((name: string) => any) & IRouterMatcher<this>;
+
+    param(name: string | string[], handler: RequestParamHandler): this;
+
+    /**
+     * Alternatively, you can pass only a callback, in which case you have the opportunity to alter the app.param()
+     *
+     * @deprecated since version 4.11
+     */
+    param(callback: (name: string, matcher: RegExp) => RequestParamHandler): this;
+
+    /**
+     * Return the app's absolute pathname
+     * based on the parent(s) that have
+     * mounted it.
+     *
+     * For example if the application was
+     * mounted as "/admin", which itself
+     * was mounted as "/blog" then the
+     * return value would be "/blog/admin".
+     */
+    path(): string;
+
+    /**
+     * Check if `setting` is enabled (truthy).
+     *
+     *    app.enabled('foo')
+     *    // => false
+     *
+     *    app.enable('foo')
+     *    app.enabled('foo')
+     *    // => true
+     */
+    enabled(setting: string): boolean;
+
+    /**
+     * Check if `setting` is disabled.
+     *
+     *    app.disabled('foo')
+     *    // => true
+     *
+     *    app.enable('foo')
+     *    app.disabled('foo')
+     *    // => false
+     */
+    disabled(setting: string): boolean;
+
+    /** Enable `setting`. */
+    enable(setting: string): this;
+
+    /** Disable `setting`. */
+    disable(setting: string): this;
+
+    /**
+     * Render the given view `name` name with `options`
+     * and a callback accepting an error and the
+     * rendered template string.
+     *
+     * Example:
+     *
+     *    app.render('email', { name: 'Tobi' }, function(err, html){
+     *      // ...
+     *    })
+     */
+    render(name: string, options?: object, callback?: (err: Error, html: string) => void): void;
+    render(name: string, callback: (err: Error, html: string) => void): void;
+
+    /**
+     * Listen for connections.
+     *
+     * A node `http.Server` is returned, with this
+     * application (which is a `Function`) as its
+     * callback. If you wish to create both an HTTP
+     * and HTTPS server you may do so with the "http"
+     * and "https" modules as shown here:
+     *
+     *    var http = require('http')
+     *      , https = require('https')
+     *      , express = require('express')
+     *      , app = express();
+     *
+     *    http.createServer(app).listen(80);
+     *    https.createServer({ ... }, app).listen(443);
+     */
+    listen(port: number, hostname: string, backlog: number, callback?: () => void): http.Server;
+    listen(port: number, hostname: string, callback?: () => void): http.Server;
+    listen(port: number, callback?: () => void): http.Server;
+    listen(callback?: () => void): http.Server;
+    listen(path: string, callback?: () => void): http.Server;
+    listen(handle: any, listeningListener?: () => void): http.Server;
+
+    router: string;
+
+    settings: any;
+
+    resource: any;
+
+    map: any;
+
+    locals: LocalsObj & Locals;
+
+    /**
+     * The app.routes object houses all of the routes defined mapped by the
+     * associated HTTP verb. This object may be used for introspection
+     * capabilities, for example Express uses this internally not only for
+     * routing but to provide default OPTIONS behaviour unless app.options()
+     * is used. Your application or framework may also remove routes by
+     * simply by removing them from this object.
+     */
+    routes: any;
+
+    /**
+     * Used to get all registered routes in Express Application
+     */
+    _router: any;
+
+    use: ApplicationRequestHandler<this>;
+
+    /**
+     * The mount event is fired on a sub-app, when it is mounted on a parent app.
+     * The parent app is passed to the callback function.
+     *
+     * NOTE:
+     * Sub-apps will:
+     *  - Not inherit the value of settings that have a default value. You must set the value in the sub-app.
+     *  - Inherit the value of settings with no default value.
+     */
+    on: (event: string, callback: (parent: Application) => void) => this;
+
+    /**
+     * The app.mountpath property contains one or more path patterns on which a sub-app was mounted.
+     */
+    mountpath: string | string[];
+}
+
+export interface Express extends Application {
+    request: Request;
+    response: Response;
+}

--- a/node_modules/@types/express-serve-static-core/package.json
+++ b/node_modules/@types/express-serve-static-core/package.json
@@ -1,0 +1,50 @@
+{
+    "name": "@types/express-serve-static-core",
+    "version": "4.19.5",
+    "description": "TypeScript definitions for express-serve-static-core",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/express-serve-static-core",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Boris Yankov",
+            "githubUsername": "borisyankov",
+            "url": "https://github.com/borisyankov"
+        },
+        {
+            "name": "Satana Charuwichitratana",
+            "githubUsername": "micksatana",
+            "url": "https://github.com/micksatana"
+        },
+        {
+            "name": "Jose Luis Leon",
+            "githubUsername": "JoseLion",
+            "url": "https://github.com/JoseLion"
+        },
+        {
+            "name": "David Stephens",
+            "githubUsername": "dwrss",
+            "url": "https://github.com/dwrss"
+        },
+        {
+            "name": "Shin Ando",
+            "githubUsername": "andoshin11",
+            "url": "https://github.com/andoshin11"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/express-serve-static-core"
+    },
+    "scripts": {},
+    "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+    },
+    "typesPublisherContentHash": "7851d080d9b3c122ba245a1cfebd5ae4939c12e88f52b66385cdfd02a0a916da",
+    "typeScriptVersion": "4.7"
+}

--- a/node_modules/@types/express/LICENSE
+++ b/node_modules/@types/express/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/express/README.md
+++ b/node_modules/@types/express/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/express`
+
+# Summary
+This package contains type definitions for express (http://expressjs.com).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/express.
+
+### Additional Details
+ * Last updated: Tue, 07 Nov 2023 03:09:36 GMT
+ * Dependencies: [@types/body-parser](https://npmjs.com/package/@types/body-parser), [@types/express-serve-static-core](https://npmjs.com/package/@types/express-serve-static-core), [@types/qs](https://npmjs.com/package/@types/qs), [@types/serve-static](https://npmjs.com/package/@types/serve-static)
+
+# Credits
+These definitions were written by [Boris Yankov](https://github.com/borisyankov), [China Medical University Hospital](https://github.com/CMUH), [Puneet Arora](https://github.com/puneetar), and [Dylan Frankland](https://github.com/dfrankland).

--- a/node_modules/@types/express/index.d.ts
+++ b/node_modules/@types/express/index.d.ts
@@ -1,0 +1,128 @@
+/* =================== USAGE ===================
+
+    import express = require("express");
+    var app = express();
+
+ =============================================== */
+
+/// <reference types="express-serve-static-core" />
+/// <reference types="serve-static" />
+
+import * as bodyParser from "body-parser";
+import * as core from "express-serve-static-core";
+import * as qs from "qs";
+import * as serveStatic from "serve-static";
+
+/**
+ * Creates an Express application. The express() function is a top-level function exported by the express module.
+ */
+declare function e(): core.Express;
+
+declare namespace e {
+    /**
+     * This is a built-in middleware function in Express. It parses incoming requests with JSON payloads and is based on body-parser.
+     * @since 4.16.0
+     */
+    var json: typeof bodyParser.json;
+
+    /**
+     * This is a built-in middleware function in Express. It parses incoming requests with Buffer payloads and is based on body-parser.
+     * @since 4.17.0
+     */
+    var raw: typeof bodyParser.raw;
+
+    /**
+     * This is a built-in middleware function in Express. It parses incoming requests with text payloads and is based on body-parser.
+     * @since 4.17.0
+     */
+    var text: typeof bodyParser.text;
+
+    /**
+     * These are the exposed prototypes.
+     */
+    var application: Application;
+    var request: Request;
+    var response: Response;
+
+    /**
+     * This is a built-in middleware function in Express. It serves static files and is based on serve-static.
+     */
+    var static: serveStatic.RequestHandlerConstructor<Response>;
+
+    /**
+     * This is a built-in middleware function in Express. It parses incoming requests with urlencoded payloads and is based on body-parser.
+     * @since 4.16.0
+     */
+    var urlencoded: typeof bodyParser.urlencoded;
+
+    /**
+     * This is a built-in middleware function in Express. It parses incoming request query parameters.
+     */
+    export function query(options: qs.IParseOptions | typeof qs.parse): Handler;
+
+    export function Router(options?: RouterOptions): core.Router;
+
+    interface RouterOptions {
+        /**
+         * Enable case sensitivity.
+         */
+        caseSensitive?: boolean | undefined;
+
+        /**
+         * Preserve the req.params values from the parent router.
+         * If the parent and the child have conflicting param names, the child’s value take precedence.
+         *
+         * @default false
+         * @since 4.5.0
+         */
+        mergeParams?: boolean | undefined;
+
+        /**
+         * Enable strict routing.
+         */
+        strict?: boolean | undefined;
+    }
+
+    interface Application extends core.Application {}
+    interface CookieOptions extends core.CookieOptions {}
+    interface Errback extends core.Errback {}
+    interface ErrorRequestHandler<
+        P = core.ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = core.Query,
+        Locals extends Record<string, any> = Record<string, any>,
+    > extends core.ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> {}
+    interface Express extends core.Express {}
+    interface Handler extends core.Handler {}
+    interface IRoute extends core.IRoute {}
+    interface IRouter extends core.IRouter {}
+    interface IRouterHandler<T> extends core.IRouterHandler<T> {}
+    interface IRouterMatcher<T> extends core.IRouterMatcher<T> {}
+    interface MediaType extends core.MediaType {}
+    interface NextFunction extends core.NextFunction {}
+    interface Locals extends core.Locals {}
+    interface Request<
+        P = core.ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = core.Query,
+        Locals extends Record<string, any> = Record<string, any>,
+    > extends core.Request<P, ResBody, ReqBody, ReqQuery, Locals> {}
+    interface RequestHandler<
+        P = core.ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = core.Query,
+        Locals extends Record<string, any> = Record<string, any>,
+    > extends core.RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> {}
+    interface RequestParamHandler extends core.RequestParamHandler {}
+    interface Response<
+        ResBody = any,
+        Locals extends Record<string, any> = Record<string, any>,
+    > extends core.Response<ResBody, Locals> {}
+    interface Router extends core.Router {}
+    interface Send extends core.Send {}
+}
+
+export = e;

--- a/node_modules/@types/express/package.json
+++ b/node_modules/@types/express/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@types/express",
+    "version": "4.17.21",
+    "description": "TypeScript definitions for express",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/express",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Boris Yankov",
+            "githubUsername": "borisyankov",
+            "url": "https://github.com/borisyankov"
+        },
+        {
+            "name": "China Medical University Hospital",
+            "githubUsername": "CMUH",
+            "url": "https://github.com/CMUH"
+        },
+        {
+            "name": "Puneet Arora",
+            "githubUsername": "puneetar",
+            "url": "https://github.com/puneetar"
+        },
+        {
+            "name": "Dylan Frankland",
+            "githubUsername": "dfrankland",
+            "url": "https://github.com/dfrankland"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/express"
+    },
+    "scripts": {},
+    "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+    },
+    "typesPublisherContentHash": "fa18ce9be07653182e2674f9a13cf8347ffb270031a7a8d22ba0e785bbc16ce4",
+    "typeScriptVersion": "4.5"
+}

--- a/node_modules/@types/http-errors/LICENSE
+++ b/node_modules/@types/http-errors/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/http-errors/README.md
+++ b/node_modules/@types/http-errors/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/http-errors`
+
+# Summary
+This package contains type definitions for http-errors (https://github.com/jshttp/http-errors).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/http-errors.
+
+### Additional Details
+ * Last updated: Tue, 07 Nov 2023 03:09:37 GMT
+ * Dependencies: none
+
+# Credits
+These definitions were written by [Tanguy Krotoff](https://github.com/tkrotoff), and [BendingBender](https://github.com/BendingBender).

--- a/node_modules/@types/http-errors/index.d.ts
+++ b/node_modules/@types/http-errors/index.d.ts
@@ -1,0 +1,77 @@
+export = createHttpError;
+
+declare const createHttpError: createHttpError.CreateHttpError & createHttpError.NamedConstructors & {
+    isHttpError: createHttpError.IsHttpError;
+};
+
+declare namespace createHttpError {
+    interface HttpError<N extends number = number> extends Error {
+        status: N;
+        statusCode: N;
+        expose: boolean;
+        headers?: {
+            [key: string]: string;
+        } | undefined;
+        [key: string]: any;
+    }
+
+    type UnknownError = Error | string | { [key: string]: any };
+
+    interface HttpErrorConstructor<N extends number = number> {
+        (msg?: string): HttpError<N>;
+        new(msg?: string): HttpError<N>;
+    }
+
+    interface CreateHttpError {
+        <N extends number = number>(arg: N, ...rest: UnknownError[]): HttpError<N>;
+        (...rest: UnknownError[]): HttpError;
+    }
+
+    type IsHttpError = (error: unknown) => error is HttpError;
+
+    type NamedConstructors =
+        & {
+            HttpError: HttpErrorConstructor;
+        }
+        & Record<"BadRequest" | "400", HttpErrorConstructor<400>>
+        & Record<"Unauthorized" | "401", HttpErrorConstructor<401>>
+        & Record<"PaymentRequired" | "402", HttpErrorConstructor<402>>
+        & Record<"Forbidden" | "403", HttpErrorConstructor<403>>
+        & Record<"NotFound" | "404", HttpErrorConstructor<404>>
+        & Record<"MethodNotAllowed" | "405", HttpErrorConstructor<405>>
+        & Record<"NotAcceptable" | "406", HttpErrorConstructor<406>>
+        & Record<"ProxyAuthenticationRequired" | "407", HttpErrorConstructor<407>>
+        & Record<"RequestTimeout" | "408", HttpErrorConstructor<408>>
+        & Record<"Conflict" | "409", HttpErrorConstructor<409>>
+        & Record<"Gone" | "410", HttpErrorConstructor<410>>
+        & Record<"LengthRequired" | "411", HttpErrorConstructor<411>>
+        & Record<"PreconditionFailed" | "412", HttpErrorConstructor<412>>
+        & Record<"PayloadTooLarge" | "413", HttpErrorConstructor<413>>
+        & Record<"URITooLong" | "414", HttpErrorConstructor<414>>
+        & Record<"UnsupportedMediaType" | "415", HttpErrorConstructor<415>>
+        & Record<"RangeNotSatisfiable" | "416", HttpErrorConstructor<416>>
+        & Record<"ExpectationFailed" | "417", HttpErrorConstructor<417>>
+        & Record<"ImATeapot" | "418", HttpErrorConstructor<418>>
+        & Record<"MisdirectedRequest" | "421", HttpErrorConstructor<421>>
+        & Record<"UnprocessableEntity" | "422", HttpErrorConstructor<422>>
+        & Record<"Locked" | "423", HttpErrorConstructor<423>>
+        & Record<"FailedDependency" | "424", HttpErrorConstructor<424>>
+        & Record<"TooEarly" | "425", HttpErrorConstructor<425>>
+        & Record<"UpgradeRequired" | "426", HttpErrorConstructor<426>>
+        & Record<"PreconditionRequired" | "428", HttpErrorConstructor<428>>
+        & Record<"TooManyRequests" | "429", HttpErrorConstructor<429>>
+        & Record<"RequestHeaderFieldsTooLarge" | "431", HttpErrorConstructor<431>>
+        & Record<"UnavailableForLegalReasons" | "451", HttpErrorConstructor<451>>
+        & Record<"InternalServerError" | "500", HttpErrorConstructor<500>>
+        & Record<"NotImplemented" | "501", HttpErrorConstructor<501>>
+        & Record<"BadGateway" | "502", HttpErrorConstructor<502>>
+        & Record<"ServiceUnavailable" | "503", HttpErrorConstructor<503>>
+        & Record<"GatewayTimeout" | "504", HttpErrorConstructor<504>>
+        & Record<"HTTPVersionNotSupported" | "505", HttpErrorConstructor<505>>
+        & Record<"VariantAlsoNegotiates" | "506", HttpErrorConstructor<506>>
+        & Record<"InsufficientStorage" | "507", HttpErrorConstructor<507>>
+        & Record<"LoopDetected" | "508", HttpErrorConstructor<508>>
+        & Record<"BandwidthLimitExceeded" | "509", HttpErrorConstructor<509>>
+        & Record<"NotExtended" | "510", HttpErrorConstructor<510>>
+        & Record<"NetworkAuthenticationRequire" | "511", HttpErrorConstructor<511>>;
+}

--- a/node_modules/@types/http-errors/package.json
+++ b/node_modules/@types/http-errors/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "@types/http-errors",
+    "version": "2.0.4",
+    "description": "TypeScript definitions for http-errors",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/http-errors",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Tanguy Krotoff",
+            "githubUsername": "tkrotoff",
+            "url": "https://github.com/tkrotoff"
+        },
+        {
+            "name": "BendingBender",
+            "githubUsername": "BendingBender",
+            "url": "https://github.com/BendingBender"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/http-errors"
+    },
+    "scripts": {},
+    "dependencies": {},
+    "typesPublisherContentHash": "06e33723b60f818facd3b7dd2025f043142fb7c56ab4832babafeb9470f2086f",
+    "typeScriptVersion": "4.5"
+}

--- a/node_modules/@types/mime/LICENSE
+++ b/node_modules/@types/mime/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/mime/Mime.d.ts
+++ b/node_modules/@types/mime/Mime.d.ts
@@ -1,0 +1,10 @@
+import { TypeMap } from "./index";
+
+export default class Mime {
+    constructor(mimes: TypeMap);
+
+    lookup(path: string, fallback?: string): string;
+    extension(mime: string): string | undefined;
+    load(filepath: string): void;
+    define(mimes: TypeMap): void;
+}

--- a/node_modules/@types/mime/README.md
+++ b/node_modules/@types/mime/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/mime`
+
+# Summary
+This package contains type definitions for mime (https://github.com/broofa/node-mime).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mime/v1.
+
+### Additional Details
+ * Last updated: Tue, 07 Nov 2023 20:08:00 GMT
+ * Dependencies: none
+
+# Credits
+These definitions were written by [Jeff Goddard](https://github.com/jedigo), and [Daniel Hritzkiv](https://github.com/dhritzkiv).

--- a/node_modules/@types/mime/index.d.ts
+++ b/node_modules/@types/mime/index.d.ts
@@ -1,0 +1,31 @@
+// Originally imported from: https://github.com/soywiz/typescript-node-definitions/mime.d.ts
+
+export as namespace mime;
+
+export interface TypeMap {
+    [key: string]: string[];
+}
+
+/**
+ * Look up a mime type based on extension.
+ *
+ * If not found, uses the fallback argument if provided, and otherwise
+ * uses `default_type`.
+ */
+export function lookup(path: string, fallback?: string): string;
+/**
+ * Return a file extensions associated with a mime type.
+ */
+export function extension(mime: string): string | undefined;
+/**
+ * Load an Apache2-style ".types" file.
+ */
+export function load(filepath: string): void;
+export function define(mimes: TypeMap): void;
+
+export interface Charsets {
+    lookup(mime: string, fallback: string): string;
+}
+
+export const charsets: Charsets;
+export const default_type: string;

--- a/node_modules/@types/mime/lite.d.ts
+++ b/node_modules/@types/mime/lite.d.ts
@@ -1,0 +1,7 @@
+import { default as Mime } from "./Mime";
+
+declare const mimelite: Mime;
+
+export as namespace mimelite;
+
+export = mimelite;

--- a/node_modules/@types/mime/package.json
+++ b/node_modules/@types/mime/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "@types/mime",
+    "version": "1.3.5",
+    "description": "TypeScript definitions for mime",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mime",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Jeff Goddard",
+            "githubUsername": "jedigo",
+            "url": "https://github.com/jedigo"
+        },
+        {
+            "name": "Daniel Hritzkiv",
+            "githubUsername": "dhritzkiv",
+            "url": "https://github.com/dhritzkiv"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/mime"
+    },
+    "scripts": {},
+    "dependencies": {},
+    "typesPublisherContentHash": "2ad7ee9a549e6721825e733c6a1a7e8bee0ca7ba93d9ab922c8f4558def52d77",
+    "typeScriptVersion": "4.5"
+}

--- a/node_modules/@types/qs/LICENSE
+++ b/node_modules/@types/qs/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/qs/README.md
+++ b/node_modules/@types/qs/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/qs`
+
+# Summary
+This package contains type definitions for qs (https://github.com/ljharb/qs).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/qs.
+
+### Additional Details
+ * Last updated: Sat, 14 Sep 2024 02:47:27 GMT
+ * Dependencies: none
+
+# Credits
+These definitions were written by [Roman Korneev](https://github.com/RWander), [Leon Yu](https://github.com/leonyu), [Belinda Teh](https://github.com/tehbelinda), [Melvin Lee](https://github.com/zyml), [Arturs Vonda](https://github.com/artursvonda), [Carlos Bonetti](https://github.com/CarlosBonetti), [Dan Smith](https://github.com/dpsmith3), [Hunter Perrin](https://github.com/hperrin), and [Jordan Harband](https://github.com/ljharb).

--- a/node_modules/@types/qs/index.d.ts
+++ b/node_modules/@types/qs/index.d.ts
@@ -1,0 +1,80 @@
+export = QueryString;
+export as namespace qs;
+
+declare namespace QueryString {
+    type defaultEncoder = (str: any, defaultEncoder?: any, charset?: string) => string;
+    type defaultDecoder = (str: string, decoder?: any, charset?: string) => string;
+
+    type BooleanOptional = boolean | undefined;
+
+    interface IStringifyBaseOptions {
+        delimiter?: string | undefined;
+        strictNullHandling?: boolean | undefined;
+        skipNulls?: boolean | undefined;
+        encode?: boolean | undefined;
+        encoder?:
+            | ((str: any, defaultEncoder: defaultEncoder, charset: string, type: "key" | "value") => string)
+            | undefined;
+        filter?: Array<string | number> | ((prefix: string, value: any) => any) | undefined;
+        arrayFormat?: "indices" | "brackets" | "repeat" | "comma" | undefined;
+        indices?: boolean | undefined;
+        sort?: ((a: string, b: string) => number) | undefined;
+        serializeDate?: ((d: Date) => string) | undefined;
+        format?: "RFC1738" | "RFC3986" | undefined;
+        encodeValuesOnly?: boolean | undefined;
+        addQueryPrefix?: boolean | undefined;
+        charset?: "utf-8" | "iso-8859-1" | undefined;
+        charsetSentinel?: boolean | undefined;
+        allowEmptyArrays?: boolean | undefined;
+        commaRoundTrip?: boolean | undefined;
+    }
+
+    type IStringifyDynamicOptions<AllowDots extends BooleanOptional> = AllowDots extends true
+        ? { allowDots?: AllowDots; encodeDotInKeys?: boolean }
+        : { allowDots?: boolean; encodeDotInKeys?: false };
+
+    type IStringifyOptions<AllowDots extends BooleanOptional = undefined> =
+        & IStringifyBaseOptions
+        & IStringifyDynamicOptions<AllowDots>;
+
+    interface IParseBaseOptions {
+        comma?: boolean | undefined;
+        delimiter?: string | RegExp | undefined;
+        depth?: number | false | undefined;
+        decoder?:
+            | ((str: string, defaultDecoder: defaultDecoder, charset: string, type: "key" | "value") => any)
+            | undefined;
+        arrayLimit?: number | undefined;
+        parseArrays?: boolean | undefined;
+        plainObjects?: boolean | undefined;
+        allowPrototypes?: boolean | undefined;
+        allowSparse?: boolean | undefined;
+        parameterLimit?: number | undefined;
+        strictNullHandling?: boolean | undefined;
+        ignoreQueryPrefix?: boolean | undefined;
+        charset?: "utf-8" | "iso-8859-1" | undefined;
+        charsetSentinel?: boolean | undefined;
+        interpretNumericEntities?: boolean | undefined;
+        allowEmptyArrays?: boolean | undefined;
+        duplicates?: "combine" | "first" | "last" | undefined;
+    }
+
+    type IParseDynamicOptions<AllowDots extends BooleanOptional> = AllowDots extends true
+        ? { allowDots?: AllowDots; decodeDotInKeys?: boolean }
+        : { allowDots?: boolean; decodeDotInKeys?: false };
+
+    type IParseOptions<AllowDots extends BooleanOptional = undefined> =
+        & IParseBaseOptions
+        & IParseDynamicOptions<AllowDots>;
+
+    interface ParsedQs {
+        [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[];
+    }
+
+    function stringify(obj: any, options?: IStringifyOptions<BooleanOptional>): string;
+    function parse(str: string, options?: IParseOptions<BooleanOptional> & { decoder?: never | undefined }): ParsedQs;
+    function parse(
+        str: string | Record<string, string>,
+        options?: IParseOptions<BooleanOptional>,
+    ): { [key: string]: unknown };
+}

--- a/node_modules/@types/qs/package.json
+++ b/node_modules/@types/qs/package.json
@@ -1,0 +1,65 @@
+{
+    "name": "@types/qs",
+    "version": "6.9.16",
+    "description": "TypeScript definitions for qs",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/qs",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Roman Korneev",
+            "githubUsername": "RWander",
+            "url": "https://github.com/RWander"
+        },
+        {
+            "name": "Leon Yu",
+            "githubUsername": "leonyu",
+            "url": "https://github.com/leonyu"
+        },
+        {
+            "name": "Belinda Teh",
+            "githubUsername": "tehbelinda",
+            "url": "https://github.com/tehbelinda"
+        },
+        {
+            "name": "Melvin Lee",
+            "githubUsername": "zyml",
+            "url": "https://github.com/zyml"
+        },
+        {
+            "name": "Arturs Vonda",
+            "githubUsername": "artursvonda",
+            "url": "https://github.com/artursvonda"
+        },
+        {
+            "name": "Carlos Bonetti",
+            "githubUsername": "CarlosBonetti",
+            "url": "https://github.com/CarlosBonetti"
+        },
+        {
+            "name": "Dan Smith",
+            "githubUsername": "dpsmith3",
+            "url": "https://github.com/dpsmith3"
+        },
+        {
+            "name": "Hunter Perrin",
+            "githubUsername": "hperrin",
+            "url": "https://github.com/hperrin"
+        },
+        {
+            "name": "Jordan Harband",
+            "githubUsername": "ljharb",
+            "url": "https://github.com/ljharb"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/qs"
+    },
+    "scripts": {},
+    "dependencies": {},
+    "typesPublisherContentHash": "a1c6974752cb85bef9651c5d9da8b5ba4f2ed34e8cea6cdaede247cf333eec2c",
+    "typeScriptVersion": "4.8"
+}

--- a/node_modules/@types/range-parser/LICENSE
+++ b/node_modules/@types/range-parser/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/range-parser/README.md
+++ b/node_modules/@types/range-parser/README.md
@@ -1,0 +1,53 @@
+# Installation
+> `npm install --save @types/range-parser`
+
+# Summary
+This package contains type definitions for range-parser (https://github.com/jshttp/range-parser).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/range-parser.
+## [index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/range-parser/index.d.ts)
+````ts
+/**
+ * When ranges are returned, the array has a "type" property which is the type of
+ * range that is required (most commonly, "bytes"). Each array element is an object
+ * with a "start" and "end" property for the portion of the range.
+ *
+ * @returns `-1` when unsatisfiable and `-2` when syntactically invalid, ranges otherwise.
+ */
+declare function RangeParser(
+    size: number,
+    str: string,
+    options?: RangeParser.Options,
+): RangeParser.Result | RangeParser.Ranges;
+
+declare namespace RangeParser {
+    interface Ranges extends Array<Range> {
+        type: string;
+    }
+    interface Range {
+        start: number;
+        end: number;
+    }
+    interface Options {
+        /**
+         * The "combine" option can be set to `true` and overlapping & adjacent ranges
+         * will be combined into a single range.
+         */
+        combine?: boolean | undefined;
+    }
+    type ResultUnsatisfiable = -1;
+    type ResultInvalid = -2;
+    type Result = ResultUnsatisfiable | ResultInvalid;
+}
+
+export = RangeParser;
+
+````
+
+### Additional Details
+ * Last updated: Tue, 07 Nov 2023 09:09:39 GMT
+ * Dependencies: none
+
+# Credits
+These definitions were written by [Tomek Łaziuk](https://github.com/tlaziuk).

--- a/node_modules/@types/range-parser/index.d.ts
+++ b/node_modules/@types/range-parser/index.d.ts
@@ -1,0 +1,34 @@
+/**
+ * When ranges are returned, the array has a "type" property which is the type of
+ * range that is required (most commonly, "bytes"). Each array element is an object
+ * with a "start" and "end" property for the portion of the range.
+ *
+ * @returns `-1` when unsatisfiable and `-2` when syntactically invalid, ranges otherwise.
+ */
+declare function RangeParser(
+    size: number,
+    str: string,
+    options?: RangeParser.Options,
+): RangeParser.Result | RangeParser.Ranges;
+
+declare namespace RangeParser {
+    interface Ranges extends Array<Range> {
+        type: string;
+    }
+    interface Range {
+        start: number;
+        end: number;
+    }
+    interface Options {
+        /**
+         * The "combine" option can be set to `true` and overlapping & adjacent ranges
+         * will be combined into a single range.
+         */
+        combine?: boolean | undefined;
+    }
+    type ResultUnsatisfiable = -1;
+    type ResultInvalid = -2;
+    type Result = ResultUnsatisfiable | ResultInvalid;
+}
+
+export = RangeParser;

--- a/node_modules/@types/range-parser/package.json
+++ b/node_modules/@types/range-parser/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@types/range-parser",
+    "version": "1.2.7",
+    "description": "TypeScript definitions for range-parser",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/range-parser",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Tomek Łaziuk",
+            "githubUsername": "tlaziuk",
+            "url": "https://github.com/tlaziuk"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/range-parser"
+    },
+    "scripts": {},
+    "dependencies": {},
+    "typesPublisherContentHash": "85ed88e3afe8da85360c400901b67e99a7c6690c6376c5ab8939ae9dee4b0a93",
+    "typeScriptVersion": "4.5"
+}

--- a/node_modules/@types/send/LICENSE
+++ b/node_modules/@types/send/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/send/README.md
+++ b/node_modules/@types/send/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/send`
+
+# Summary
+This package contains type definitions for send (https://github.com/pillarjs/send).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/send.
+
+### Additional Details
+ * Last updated: Tue, 07 Nov 2023 15:11:36 GMT
+ * Dependencies: [@types/mime](https://npmjs.com/package/@types/mime), [@types/node](https://npmjs.com/package/@types/node)
+
+# Credits
+These definitions were written by [Mike Jerred](https://github.com/MikeJerred), and [Piotr Błażejewicz](https://github.com/peterblazejewicz).

--- a/node_modules/@types/send/index.d.ts
+++ b/node_modules/@types/send/index.d.ts
@@ -1,0 +1,225 @@
+/// <reference types="node" />
+
+import * as fs from "fs";
+import * as m from "mime";
+import * as stream from "stream";
+
+/**
+ * Create a new SendStream for the given path to send to a res.
+ * The req is the Node.js HTTP request and the path is a urlencoded path to send (urlencoded, not the actual file-system path).
+ */
+declare function send(req: stream.Readable, path: string, options?: send.SendOptions): send.SendStream;
+
+declare namespace send {
+    const mime: typeof m;
+    interface SendOptions {
+        /**
+         * Enable or disable accepting ranged requests, defaults to true.
+         * Disabling this will not send Accept-Ranges and ignore the contents of the Range request header.
+         */
+        acceptRanges?: boolean | undefined;
+
+        /**
+         * Enable or disable setting Cache-Control response header, defaults to true.
+         * Disabling this will ignore the maxAge option.
+         */
+        cacheControl?: boolean | undefined;
+
+        /**
+         * Set how "dotfiles" are treated when encountered.
+         * A dotfile is a file or directory that begins with a dot (".").
+         * Note this check is done on the path itself without checking if the path actually exists on the disk.
+         * If root is specified, only the dotfiles above the root are checked (i.e. the root itself can be within a dotfile when when set to "deny").
+         * 'allow' No special treatment for dotfiles.
+         * 'deny' Send a 403 for any request for a dotfile.
+         * 'ignore' Pretend like the dotfile does not exist and 404.
+         * The default value is similar to 'ignore', with the exception that this default will not ignore the files within a directory that begins with a dot, for backward-compatibility.
+         */
+        dotfiles?: "allow" | "deny" | "ignore" | undefined;
+
+        /**
+         * Byte offset at which the stream ends, defaults to the length of the file minus 1.
+         * The end is inclusive in the stream, meaning end: 3 will include the 4th byte in the stream.
+         */
+        end?: number | undefined;
+
+        /**
+         * Enable or disable etag generation, defaults to true.
+         */
+        etag?: boolean | undefined;
+
+        /**
+         * If a given file doesn't exist, try appending one of the given extensions, in the given order.
+         * By default, this is disabled (set to false).
+         * An example value that will serve extension-less HTML files: ['html', 'htm'].
+         * This is skipped if the requested file already has an extension.
+         */
+        extensions?: string[] | string | boolean | undefined;
+
+        /**
+         * Enable or disable the immutable directive in the Cache-Control response header, defaults to false.
+         * If set to true, the maxAge option should also be specified to enable caching.
+         * The immutable directive will prevent supported clients from making conditional requests during the life of the maxAge option to check if the file has changed.
+         * @default false
+         */
+        immutable?: boolean | undefined;
+
+        /**
+         * By default send supports "index.html" files, to disable this set false or to supply a new index pass a string or an array in preferred order.
+         */
+        index?: string[] | string | boolean | undefined;
+
+        /**
+         * Enable or disable Last-Modified header, defaults to true.
+         * Uses the file system's last modified value.
+         */
+        lastModified?: boolean | undefined;
+
+        /**
+         * Provide a max-age in milliseconds for http caching, defaults to 0.
+         * This can also be a string accepted by the ms module.
+         */
+        maxAge?: string | number | undefined;
+
+        /**
+         * Serve files relative to path.
+         */
+        root?: string | undefined;
+
+        /**
+         * Byte offset at which the stream starts, defaults to 0.
+         * The start is inclusive, meaning start: 2 will include the 3rd byte in the stream.
+         */
+        start?: number | undefined;
+    }
+
+    interface SendStream extends stream.Stream {
+        /**
+         * @deprecated pass etag as option
+         * Enable or disable etag generation.
+         */
+        etag(val: boolean): SendStream;
+
+        /**
+         * @deprecated use dotfiles option
+         * Enable or disable "hidden" (dot) files.
+         */
+        hidden(val: boolean): SendStream;
+
+        /**
+         * @deprecated pass index as option
+         * Set index `paths`, set to a falsy value to disable index support.
+         */
+        index(paths: string[] | string): SendStream;
+
+        /**
+         * @deprecated pass root as option
+         * Set root `path`.
+         */
+        root(paths: string): SendStream;
+
+        /**
+         * @deprecated pass root as option
+         * Set root `path`.
+         */
+        from(paths: string): SendStream;
+
+        /**
+         * @deprecated pass maxAge as option
+         * Set max-age to `maxAge`.
+         */
+        maxage(maxAge: string | number): SendStream;
+
+        /**
+         * Emit error with `status`.
+         */
+        error(status: number, error?: Error): void;
+
+        /**
+         * Check if the pathname ends with "/".
+         */
+        hasTrailingSlash(): boolean;
+
+        /**
+         * Check if this is a conditional GET request.
+         */
+        isConditionalGET(): boolean;
+
+        /**
+         * Strip content-* header fields.
+         */
+        removeContentHeaderFields(): void;
+
+        /**
+         * Respond with 304 not modified.
+         */
+        notModified(): void;
+
+        /**
+         * Raise error that headers already sent.
+         */
+        headersAlreadySent(): void;
+
+        /**
+         * Check if the request is cacheable, aka responded with 2xx or 304 (see RFC 2616 section 14.2{5,6}).
+         */
+        isCachable(): boolean;
+
+        /**
+         * Handle stat() error.
+         */
+        onStatError(error: Error): void;
+
+        /**
+         * Check if the cache is fresh.
+         */
+        isFresh(): boolean;
+
+        /**
+         * Check if the range is fresh.
+         */
+        isRangeFresh(): boolean;
+
+        /**
+         * Redirect to path.
+         */
+        redirect(path: string): void;
+
+        /**
+         * Pipe to `res`.
+         */
+        pipe<T extends NodeJS.WritableStream>(res: T): T;
+
+        /**
+         * Transfer `path`.
+         */
+        send(path: string, stat?: fs.Stats): void;
+
+        /**
+         * Transfer file for `path`.
+         */
+        sendFile(path: string): void;
+
+        /**
+         * Transfer index for `path`.
+         */
+        sendIndex(path: string): void;
+
+        /**
+         * Transfer index for `path`.
+         */
+        stream(path: string, options?: {}): void;
+
+        /**
+         * Set content-type based on `path` if it hasn't been explicitly set.
+         */
+        type(path: string): void;
+
+        /**
+         * Set response header fields, most fields may be pre-defined.
+         */
+        setHeader(path: string, stat: fs.Stats): void;
+    }
+}
+
+export = send;

--- a/node_modules/@types/send/package.json
+++ b/node_modules/@types/send/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "@types/send",
+    "version": "0.17.4",
+    "description": "TypeScript definitions for send",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/send",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Mike Jerred",
+            "githubUsername": "MikeJerred",
+            "url": "https://github.com/MikeJerred"
+        },
+        {
+            "name": "Piotr Błażejewicz",
+            "githubUsername": "peterblazejewicz",
+            "url": "https://github.com/peterblazejewicz"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/send"
+    },
+    "scripts": {},
+    "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+    },
+    "typesPublisherContentHash": "80c2c0bda207c1a802cfc46bf20e4f774429c8ae1e9808128c20468d438b895c",
+    "typeScriptVersion": "4.5"
+}

--- a/node_modules/@types/serve-static/LICENSE
+++ b/node_modules/@types/serve-static/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/serve-static/README.md
+++ b/node_modules/@types/serve-static/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/serve-static`
+
+# Summary
+This package contains type definitions for serve-static (https://github.com/expressjs/serve-static).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/serve-static.
+
+### Additional Details
+ * Last updated: Wed, 03 Apr 2024 06:07:52 GMT
+ * Dependencies: [@types/http-errors](https://npmjs.com/package/@types/http-errors), [@types/node](https://npmjs.com/package/@types/node), [@types/send](https://npmjs.com/package/@types/send)
+
+# Credits
+These definitions were written by [Uros Smolnik](https://github.com/urossmolnik), [Linus Unnebäck](https://github.com/LinusU), and [Devansh Jethmalani](https://github.com/devanshj).

--- a/node_modules/@types/serve-static/index.d.ts
+++ b/node_modules/@types/serve-static/index.d.ts
@@ -1,0 +1,107 @@
+/// <reference types="node" />
+import * as http from "http";
+import { HttpError } from "http-errors";
+import * as send from "send";
+
+/**
+ * Create a new middleware function to serve files from within a given root directory.
+ * The file to serve will be determined by combining req.url with the provided root directory.
+ * When a file is not found, instead of sending a 404 response, this module will instead call next() to move on to the next middleware, allowing for stacking and fall-backs.
+ */
+declare function serveStatic<R extends http.ServerResponse>(
+    root: string,
+    options?: serveStatic.ServeStaticOptions<R>,
+): serveStatic.RequestHandler<R>;
+
+declare namespace serveStatic {
+    var mime: typeof send.mime;
+    interface ServeStaticOptions<R extends http.ServerResponse = http.ServerResponse> {
+        /**
+         * Enable or disable accepting ranged requests, defaults to true.
+         * Disabling this will not send Accept-Ranges and ignore the contents of the Range request header.
+         */
+        acceptRanges?: boolean | undefined;
+
+        /**
+         * Enable or disable setting Cache-Control response header, defaults to true.
+         * Disabling this will ignore the immutable and maxAge options.
+         */
+        cacheControl?: boolean | undefined;
+
+        /**
+         * Set how "dotfiles" are treated when encountered. A dotfile is a file or directory that begins with a dot (".").
+         * Note this check is done on the path itself without checking if the path actually exists on the disk.
+         * If root is specified, only the dotfiles above the root are checked (i.e. the root itself can be within a dotfile when when set to "deny").
+         * The default value is 'ignore'.
+         * 'allow' No special treatment for dotfiles
+         * 'deny' Send a 403 for any request for a dotfile
+         * 'ignore' Pretend like the dotfile does not exist and call next()
+         */
+        dotfiles?: string | undefined;
+
+        /**
+         * Enable or disable etag generation, defaults to true.
+         */
+        etag?: boolean | undefined;
+
+        /**
+         * Set file extension fallbacks. When set, if a file is not found, the given extensions will be added to the file name and search for.
+         * The first that exists will be served. Example: ['html', 'htm'].
+         * The default value is false.
+         */
+        extensions?: string[] | false | undefined;
+
+        /**
+         * Let client errors fall-through as unhandled requests, otherwise forward a client error.
+         * The default value is true.
+         */
+        fallthrough?: boolean | undefined;
+
+        /**
+         * Enable or disable the immutable directive in the Cache-Control response header.
+         * If enabled, the maxAge option should also be specified to enable caching. The immutable directive will prevent supported clients from making conditional requests during the life of the maxAge option to check if the file has changed.
+         */
+        immutable?: boolean | undefined;
+
+        /**
+         * By default this module will send "index.html" files in response to a request on a directory.
+         * To disable this set false or to supply a new index pass a string or an array in preferred order.
+         */
+        index?: boolean | string | string[] | undefined;
+
+        /**
+         * Enable or disable Last-Modified header, defaults to true. Uses the file system's last modified value.
+         */
+        lastModified?: boolean | undefined;
+
+        /**
+         * Provide a max-age in milliseconds for http caching, defaults to 0. This can also be a string accepted by the ms module.
+         */
+        maxAge?: number | string | undefined;
+
+        /**
+         * Redirect to trailing "/" when the pathname is a dir. Defaults to true.
+         */
+        redirect?: boolean | undefined;
+
+        /**
+         * Function to set custom headers on response. Alterations to the headers need to occur synchronously.
+         * The function is called as fn(res, path, stat), where the arguments are:
+         * res the response object
+         * path the file path that is being sent
+         * stat the stat object of the file that is being sent
+         */
+        setHeaders?: ((res: R, path: string, stat: any) => any) | undefined;
+    }
+
+    interface RequestHandler<R extends http.ServerResponse> {
+        (request: http.IncomingMessage, response: R, next: (err?: HttpError) => void): any;
+    }
+
+    interface RequestHandlerConstructor<R extends http.ServerResponse> {
+        (root: string, options?: ServeStaticOptions<R>): RequestHandler<R>;
+        mime: typeof send.mime;
+    }
+}
+
+export = serveStatic;

--- a/node_modules/@types/serve-static/package.json
+++ b/node_modules/@types/serve-static/package.json
@@ -1,0 +1,39 @@
+{
+    "name": "@types/serve-static",
+    "version": "1.15.7",
+    "description": "TypeScript definitions for serve-static",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/serve-static",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Uros Smolnik",
+            "githubUsername": "urossmolnik",
+            "url": "https://github.com/urossmolnik"
+        },
+        {
+            "name": "Linus Unnebäck",
+            "githubUsername": "LinusU",
+            "url": "https://github.com/LinusU"
+        },
+        {
+            "name": "Devansh Jethmalani",
+            "githubUsername": "devanshj",
+            "url": "https://github.com/devanshj"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/serve-static"
+    },
+    "scripts": {},
+    "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+    },
+    "typesPublisherContentHash": "781872d0ec274d5e3360acd4087e25d9d8440401b99181fe8cd1fc968aa78b14",
+    "typeScriptVersion": "4.7"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "express": "^4.21.0"
       },
       "devDependencies": {
+        "@types/express": "^4.17.21",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.6.2"
       }
@@ -77,14 +78,101 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "22.5.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
       "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.16",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
+      "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/strip-bom": {
@@ -1345,8 +1433,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.21.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.2"
   }

--- a/src/controllers/recipesController.ts
+++ b/src/controllers/recipesController.ts
@@ -1,0 +1,63 @@
+import { Request, Response } from 'express';
+import Recipe from '../models/Recipe';
+
+export const getRecipes = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const recipes = await Recipe.find();
+        res.status(200).json(recipes);
+    } catch (error) {
+        res.status(500).json({ message: 'Error fetching recipes' });
+    }
+};
+
+export const getRecipeById = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const { id } = req.params;
+        const recipe = await Recipe.findById(id);
+        if(recipe) {
+            res.status(200).json(recipe);
+        } else {
+            res.status(404).json({ message: 'Recipe not found' });
+        }
+    } catch (error) {
+        res.status(500).json({ message: 'Error fetching recipe' });
+    }
+};
+
+export const createRecipe = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const newRecipe = new Recipe(req.body);
+        const savedRecipe = await newRecipe.save();
+        res.status(201).json(savedRecipe);
+    } catch (error) {
+        res.status(500).json({ message: 'Error creating recipe' });
+    }
+};
+
+export const updateRecipe = async (req: Request, res: Response): Promise<void> => { 
+    try {
+        const updateRecipe = await Recipe.findByIdAndUpdate(req.params.id, req.body, { new: true });
+        if(updateRecipe) {
+            res.status(200).json(updateRecipe);
+        } else {
+            res.status(404).json({ message: 'Recipe not found' });
+        }
+    } catch (error) {
+        res.status(500).json({ message: 'Error updating recipe' });
+    }
+};
+
+export const deleteRecipe = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const deleteRecipe = await Recipe.findByIdAndDelete(req.params.id);
+        if(deleteRecipe) {
+            res.status(200).json({ message: 'Recipe deleted successfully' });
+        } else {
+            res.status(404).json({ message: 'Recipe not found' });
+        }
+    } catch (error) {
+        res.status(500).json({ message: 'Error deleting recipe'});
+    }
+};
+
+

--- a/src/models/Recipe.ts
+++ b/src/models/Recipe.ts
@@ -1,0 +1,45 @@
+import mongoose, { Schema, Document} from "mongoose";
+
+export interface IRecipe extends Document {
+    name: string;
+    description: string; 
+    ingredients: string[]; 
+    instructions: string[];
+    preparationTime: number;
+    servings: number;
+    category: string[];
+    difficulty: string;
+    image: string[];
+    rating: number;
+    createdAt: Date;
+    author: string;
+    comments: Array<{
+        user: string;
+        comment: string;
+        date: Date;
+    }>;
+}
+
+const RecipeSchema: Schema = new Schema({
+    name: { type: String, required: true},
+    description: { type: String, required: true},
+    ingredients: { type: [String], required: true},
+    instructions: { type: [String], required: true },
+    preparationTime: { type: Number, required: true },
+    servings: { type: Number, required: true },
+    category: { type: String, required: true },
+    difficulty: { type: String, enum: ['easy', 'intermediate', 'hard'], required: true },
+    image: { type: [String], required: true }, 
+    rating: { type: Number, default: 0 },  
+    createdAt: { type: Date, default: Date.now }, 
+    author: { type: String, required: true },
+    comments: [
+        {
+          user: { type: String, required: true },
+          comment: { type: String, required: true },
+          date: { type: Date, default: Date.now },
+        }
+      ]
+});
+
+export default mongoose.model<IRecipe>('Recipe', RecipeSchema);

--- a/src/routes/recipesRoutes.ts
+++ b/src/routes/recipesRoutes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { getRecipes, getRecipeById, createRecipe, updateRecipe, deleteRecipe } from "../controllers/recipesController";
+
+const router = Router();
+
+router.route('/')
+    .get(getRecipes)
+    .post(createRecipe);
+
+router.route('/:id')
+    .get(getRecipeById)
+    .put(updateRecipe)
+    .delete(deleteRecipe);
+
+export default router;


### PR DESCRIPTION
### What
- Implemented the Recipe model in `Recipe.ts`.
- Created the Recipe controller with CRUD operations in `recipesController.ts`.
- Set up routes for Recipe in `recipesRoutes.ts`.

### Why 
- To enable the backend to handle Recipe-related operations (CRUD: Create, Read, Update, Delete).
  
### How 
- Added Mongoose model for Recipe.
- Implemented controller functions to handle API requests.
- Added RESTful routes for creating, reading, updating and deleting recipes.
